### PR TITLE
Fixed: crash due to NullPointerException in KntNBT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.dotKntrell</groupId>
     <artifactId>Underilla</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <packaging>jar</packaging>
 
     <name>Terraformer</name>
@@ -117,7 +117,7 @@
         <dependency>
             <groupId>com.jkantrell</groupId>
             <artifactId>KntNBT</artifactId>
-            <version>2.1.0</version>
+            <version>2.2.0</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Fixed: crash due to NullPointerException in KntNBT library. Updated KntNBT to latest version.