### PR TITLE
Fix use of generate_noodle_caves from config into UnderillaChunkGenerator.

### DIFF
--- a/Underilla-Spigot/build.gradle
+++ b/Underilla-Spigot/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 group = 'com.Jkantrell.mc'
-version = '1.1.1'
+version = '1.1.2'
 java.sourceCompatibility = JavaVersion.VERSION_17
 
 dependencies {

--- a/Underilla-Spigot/src/main/java/com/jkantrell/mc/underilla/spigot/generation/UnderillaChunkGenerator.java
+++ b/Underilla-Spigot/src/main/java/com/jkantrell/mc/underilla/spigot/generation/UnderillaChunkGenerator.java
@@ -79,7 +79,7 @@ public class UnderillaChunkGenerator extends ChunkGenerator {
 
     @Override
     public boolean shouldGenerateCaves(WorldInfo worldInfo, Random random, int chunkX, int chunkZ) {
-        return this.delegate_.shouldGenerateNoise(chunkX, chunkZ);
+        return this.delegate_.shouldGenerateCaves(chunkX, chunkZ);
     }
 
     @Override


### PR DESCRIPTION
As you explain to me in #6, I have used `generate_noodle_caves: false` in config, but nothing was different.

So I search into the code and find out that this boolean was never used by UnderillaChunkGenerator. It's probably only a copy paste mistake.