### PR TITLE
2 more features: Add preserve_biomes and keep_reference_world_ores

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,7 @@ If you're going to plug your custom WorldPainter world into Underilla, consider 
 - Don't user the resource layer. Underilla will have the vanilla generator take care of that for you.
 - The Populate layer has no effect. Weather all or none of the terrain will be populated based on the above point.
 - If you have custom cave/tunnels layers and want to preserve them during the merge, you'd want to use the Relative merge strategy
+
+
+## Build
+Create working jar with `gradle buildDependents`

--- a/Underilla-Core/build.gradle
+++ b/Underilla-Core/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'com.Jkantrell.mc'
-version = '1.1.0'
+version = '1.1.3'
 java.sourceCompatibility = JavaVersion.VERSION_17
 
 repositories {

--- a/Underilla-Core/src/main/java/com/jkantrell/mc/underilla/core/generation/AbsoluteMerger.java
+++ b/Underilla-Core/src/main/java/com/jkantrell/mc/underilla/core/generation/AbsoluteMerger.java
@@ -1,5 +1,6 @@
 package com.jkantrell.mc.underilla.core.generation;
 
+import java.util.List;
 import com.jkantrell.mc.underilla.core.api.Biome;
 import com.jkantrell.mc.underilla.core.api.Block;
 import com.jkantrell.mc.underilla.core.api.ChunkData;
@@ -14,12 +15,14 @@ class AbsoluteMerger implements Merger {
     //FIELDS
     private final WorldReader worldReader_;
     private final int height_;
+    private final List<? extends Biome> preserveBiomes_;
 
 
     //CONSTRUCTORS
-    AbsoluteMerger(WorldReader worldReader, int height) {
+    AbsoluteMerger(WorldReader worldReader, int height, List<? extends Biome> preserveBiomes) {
         this.worldReader_ = worldReader;
         this.height_ = height;
+        this.preserveBiomes_ = preserveBiomes;
     }
 
 
@@ -34,6 +37,7 @@ class AbsoluteMerger implements Merger {
         Block airBlock = reader.blockFromTag(MCAUtil.airBlockTag()).get();
         int airColumn = Math.max(reader.airSectionsBottom(), this.height_);
         chunkData.setRegion(0, airColumn, 0, 16, chunkData.getMaxHeight(), 16, airBlock);
+        // TODO use preserveBiomes
 
         VectorIterable iterable = new VectorIterable(0, 16, this.height_, airColumn, 0, 16);
         for (Vector<Integer> v : iterable) {

--- a/Underilla-Core/src/main/java/com/jkantrell/mc/underilla/core/generation/GenerationConfig.java
+++ b/Underilla-Core/src/main/java/com/jkantrell/mc/underilla/core/generation/GenerationConfig.java
@@ -25,6 +25,8 @@ public class GenerationConfig {
 
     public List<? extends Biome> keepUndergroundBiomes = Collections.emptyList();
 
+    public List<? extends Biome> preserveBiomes = Collections.emptyList();
+
     public int mergeLimit = 22;
 
     public int mergeBlendRange = 8;

--- a/Underilla-Core/src/main/java/com/jkantrell/mc/underilla/core/generation/GenerationConfig.java
+++ b/Underilla-Core/src/main/java/com/jkantrell/mc/underilla/core/generation/GenerationConfig.java
@@ -25,6 +25,8 @@ public class GenerationConfig {
 
     public List<? extends Biome> keepUndergroundBiomes = Collections.emptyList();
 
+    public boolean keepReferenceWorldOres = false;
+
     public List<? extends Biome> preserveBiomes = Collections.emptyList();
 
     public int mergeLimit = 22;

--- a/Underilla-Core/src/main/java/com/jkantrell/mc/underilla/core/generation/Generator.java
+++ b/Underilla-Core/src/main/java/com/jkantrell/mc/underilla/core/generation/Generator.java
@@ -25,8 +25,8 @@ public class Generator {
         this.worldReader_ = worldReader;
         this.config_ = config;
         this.merger_ = config_.mergeStrategy.equals(MergeStrategy.RELATIVE)
-                ? new RelativeMerger(this.worldReader_, config_.mergeUpperLimit, config_.mergeLowerLimit, config_.mergeDepth, config_.mergeBlendRange, config_.keepUndergroundBiomes)
-                : new AbsoluteMerger(this.worldReader_, config_.mergeStrategy.equals(MergeStrategy.NONE) ? -64 : config_.mergeLimit);
+                ? new RelativeMerger(this.worldReader_, config_.mergeUpperLimit, config_.mergeLowerLimit, config_.mergeDepth, config_.mergeBlendRange, config_.keepUndergroundBiomes, config_.preserveBiomes)
+                : new AbsoluteMerger(this.worldReader_, config_.mergeStrategy.equals(MergeStrategy.NONE) ? -64 : config_.mergeLimit, config_.preserveBiomes);
     }
 
     public int getBaseHeight(WorldInfo worldInfo, int x, int z, HeightMapType heightMap) {

--- a/Underilla-Core/src/main/java/com/jkantrell/mc/underilla/core/generation/Generator.java
+++ b/Underilla-Core/src/main/java/com/jkantrell/mc/underilla/core/generation/Generator.java
@@ -25,7 +25,7 @@ public class Generator {
         this.worldReader_ = worldReader;
         this.config_ = config;
         this.merger_ = config_.mergeStrategy.equals(MergeStrategy.RELATIVE)
-                ? new RelativeMerger(this.worldReader_, config_.mergeUpperLimit, config_.mergeLowerLimit, config_.mergeDepth, config_.mergeBlendRange, config_.keepUndergroundBiomes, config_.preserveBiomes)
+                ? new RelativeMerger(this.worldReader_, config_.mergeUpperLimit, config_.mergeLowerLimit, config_.mergeDepth, config_.mergeBlendRange, config_.keepUndergroundBiomes, config_.preserveBiomes, config_.keepReferenceWorldOres)
                 : new AbsoluteMerger(this.worldReader_, config_.mergeStrategy.equals(MergeStrategy.NONE) ? -64 : config_.mergeLimit, config_.preserveBiomes);
     }
 

--- a/Underilla-Core/src/main/java/com/jkantrell/mc/underilla/core/generation/RelativeMerger.java
+++ b/Underilla-Core/src/main/java/com/jkantrell/mc/underilla/core/generation/RelativeMerger.java
@@ -21,17 +21,18 @@ public class RelativeMerger implements Merger {
     //FIELDS
     private final WorldReader worldReader_;
     private final int upperLimit_, lowerLimit_, depth_, blendRange_;
-    private final List<? extends Biome> keptBiomes_;
+    private final List<? extends Biome> keptBiomes_, preserveBiomes_;
 
 
     //CONSTRUCTORS
-    RelativeMerger(WorldReader worldReader, int upperLimit, int lowerLimit, int depth, int transitionRange, List<? extends Biome> keptBiomes) {
+    RelativeMerger(WorldReader worldReader, int upperLimit, int lowerLimit, int depth, int transitionRange, List<? extends Biome> keptBiomes, List<? extends Biome> preservedBiomes) {
         this.worldReader_ = worldReader;
         this.upperLimit_ = upperLimit;
         this.lowerLimit_ = lowerLimit;
         this.depth_ = depth;
         this.blendRange_ = transitionRange;
         this.keptBiomes_ = keptBiomes;
+        this.preserveBiomes_ = preservedBiomes;
     }
 
 
@@ -82,9 +83,10 @@ public class RelativeMerger implements Merger {
         while (i.hasNextColumn()) {
             Vector<Integer> v = i.nextColumn();
             fillVectors.add(v);
+            boolean presevedBiome = this.preserveBiomes_.contains(chunkData.getBiome(v.x(), v.y(), v.z()));
             //if (i.hasNext()) { v = i.next(); }
             if (!RelativeMerger.isInChunk(chunkX, chunkZ, v)) { continue; }
-            while (!blockGetter.apply(v).isSolid() || this.upperLimit_ < v.y()) {
+            while (!blockGetter.apply(v).isSolid() || this.upperLimit_ < v.y() || presevedBiome) {
                 fillVectors.add(v);
                 if (!i.hasNextInColumn()) { break; }
                 v = i.next();

--- a/Underilla-Core/src/main/java/com/jkantrell/mc/underilla/core/generation/RelativeMerger.java
+++ b/Underilla-Core/src/main/java/com/jkantrell/mc/underilla/core/generation/RelativeMerger.java
@@ -83,10 +83,9 @@ public class RelativeMerger implements Merger {
         while (i.hasNextColumn()) {
             Vector<Integer> v = i.nextColumn();
             fillVectors.add(v);
-            boolean presevedBiome = this.preserveBiomes_.contains(chunkData.getBiome(v.x(), v.y(), v.z()));
             //if (i.hasNext()) { v = i.next(); }
             if (!RelativeMerger.isInChunk(chunkX, chunkZ, v)) { continue; }
-            while (!blockGetter.apply(v).isSolid() || this.upperLimit_ < v.y() || presevedBiome) {
+            while (!blockGetter.apply(v).isSolid() || this.upperLimit_ < v.y() || isPreservedBiome(reader, v)) {
                 fillVectors.add(v);
                 if (!i.hasNextInColumn()) { break; }
                 v = i.next();
@@ -108,6 +107,15 @@ public class RelativeMerger implements Merger {
                 });
 
     }
+    private boolean isPreservedBiome(ChunkReader reader, Vector v) {
+        try {
+            return this.preserveBiomes_.contains(reader.biomeAt(relativeCoordinates(v)).orElse(null));
+        }catch (IndexOutOfBoundsException e){
+            System.out.println("IndexOutOfBoundsException for "+v);
+            return false;
+        }
+    }
+
     @Override
     public void mergeBiomes(ChunkReader reader, ChunkData chunkData) {
 

--- a/Underilla-Core/src/main/java/com/jkantrell/mc/underilla/core/vector/Vector.java
+++ b/Underilla-Core/src/main/java/com/jkantrell/mc/underilla/core/vector/Vector.java
@@ -83,6 +83,11 @@ public abstract class Vector <T extends Number> implements Cloneable, Comparable
         return Math.sqrt(x + y + z);
     }
 
+    @Override
+    public String toString() {
+        return String.format("(%s, %s, %s)", this.x_, this.y_, this.z_);
+    }
+
 
     //PRIVATE
     protected abstract T add(T a, T b);

--- a/Underilla-Spigot/build.gradle
+++ b/Underilla-Spigot/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 group = 'com.Jkantrell.mc'
-version = '1.1.2'
+version = '1.1.3'
 java.sourceCompatibility = JavaVersion.VERSION_17
 
 dependencies {

--- a/Underilla-Spigot/src/main/java/com/jkantrell/mc/underilla/spigot/impl/BukkitBiome.java
+++ b/Underilla-Spigot/src/main/java/com/jkantrell/mc/underilla/spigot/impl/BukkitBiome.java
@@ -32,4 +32,11 @@ public class BukkitBiome implements Biome {
         if (!(o instanceof BukkitBiome bukkitBiome)) { return false; }
         return this.biome_.equals(bukkitBiome.biome_);
     }
+
+    @Override
+    public String toString() {
+        return "BukkitBiome{" +
+                "biome_=" + biome_ +
+                '}';
+    }
 }

--- a/Underilla-Spigot/src/main/java/com/jkantrell/mc/underilla/spigot/io/Config.java
+++ b/Underilla-Spigot/src/main/java/com/jkantrell/mc/underilla/spigot/io/Config.java
@@ -53,6 +53,9 @@ public class Config extends AbstractYamlConfig {
     @ConfigField(path = "relative.keep_underground_biomes")
     public List<Biome> keepUndergroundBiomes = List.of(Biome.DEEP_DARK, Biome.DRIPSTONE_CAVES, Biome.LUSH_CAVES);
 
+    @ConfigField(path = "relative.keep_reference_world_ores")
+    public boolean keepReferenceWorldOres = false;
+
     @ConfigField(path = "absolute.limit")
     public int mergeLimit = 22;
 
@@ -80,6 +83,7 @@ public class Config extends AbstractYamlConfig {
         r.mergeLowerLimit = this.mergeLowerLimit;
         r.mergeDepth = this.mergeDepth;
         r.keepUndergroundBiomes = this.keepUndergroundBiomes.stream().map(BukkitBiome::new).toList();
+        r.keepReferenceWorldOres = this.keepReferenceWorldOres;
         r.preserveBiomes = this.preserveBiomes.stream().map(BukkitBiome::new).toList();
         r.mergeLimit = this.mergeLimit;
         r.mergeBlendRange = this.mergeBlendRange;

--- a/Underilla-Spigot/src/main/java/com/jkantrell/mc/underilla/spigot/io/Config.java
+++ b/Underilla-Spigot/src/main/java/com/jkantrell/mc/underilla/spigot/io/Config.java
@@ -59,6 +59,9 @@ public class Config extends AbstractYamlConfig {
     @ConfigField(path = "blend_range")
     public int mergeBlendRange = 8;
 
+    @ConfigField(path = "preserve_biomes")
+    public List<Biome> preserveBiomes = List.of();
+
     @ConfigField(path = "structures.enabled")
     public Boolean generateStructures = true;
 
@@ -77,6 +80,7 @@ public class Config extends AbstractYamlConfig {
         r.mergeLowerLimit = this.mergeLowerLimit;
         r.mergeDepth = this.mergeDepth;
         r.keepUndergroundBiomes = this.keepUndergroundBiomes.stream().map(BukkitBiome::new).toList();
+        r.preserveBiomes = this.preserveBiomes.stream().map(BukkitBiome::new).toList();
         r.mergeLimit = this.mergeLimit;
         r.mergeBlendRange = this.mergeBlendRange;
         r.generateStructures = this.generateStructures;

--- a/Underilla-Spigot/src/main/resources/config.yml
+++ b/Underilla-Spigot/src/main/resources/config.yml
@@ -32,6 +32,9 @@ relative:
     - DEEP_DARK
     - DRIPSTONE_CAVES
     - LUSH_CAVES
+  # Weather or not to keep ores from reference world underground.
+  # It is usefull when vanilla_population is set to false.
+  keep_reference_world_ores: false
 
 # ABSOLUTE strategy exclusive settings
 absolute:

--- a/Underilla-Spigot/src/main/resources/config.yml
+++ b/Underilla-Spigot/src/main/resources/config.yml
@@ -42,6 +42,10 @@ absolute:
 # <= 0 results in a sharp transition.
 blend_range: 8
 
+# The biomes where vanilla underground will not be generated.
+# Biomes must be defined as spigot Biome enum constants. https://hub.spigotmc.org/javadocs/spigot/org/bukkit/block/Biome.html
+preserve_biomes: []
+
 # Weather or not to allow vanilla Minecraft populate/decorate over the reference world.
 vanilla_population: true
 


### PR DESCRIPTION
preserve_biomes is a list of biomes where vanilla underground will not be generated.
keep_reference_world_ores is a boolean. If true ores from reference world won't be replace by vanilla world blocs.

I needed this 2 features so I made them. If you don't wan't to merge it to your project, I will understand.